### PR TITLE
fix: handle empty FallbackSearchResult to prevent TypeError

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -21,8 +21,12 @@ export const CompanyResearchAnnotation = Annotation.Root({
   validatedKeyPersons: Annotation<boolean>(),
 
   // The fallback discovered key persons from the Firecrawl /search approach
-  fallbackSearchKeyPersons: Annotation<FallbackSearchResult>(),
-
+  fallbackSearchKeyPersons: Annotation<FallbackSearchResult>({
+    reducer: (state: FallbackSearchResult, update: FallbackSearchResult) => {
+      return [...state, ...update];
+    },
+    default: () => []
+  }),
   // The final merged key persons
   finalKeyPersons: Annotation<ExtractedKeyPerson[]>(),
 


### PR DESCRIPTION
A bug was encountered where the application threw a `TypeError: Cannot read properties of undefined (reading 'length') when attempting to access the length of fallbackSearchResults` if it was uninitialized or empty. 

**Fix:**
- Added a reducer function to the fallbackSearchKeyPersons annotation to properly merge state and update.
- Provided a default value for fallbackSearchKeyPersons, ensuring it initializes to an empty array ([]) if no data is present.