### PR TITLE
fix: refactor report handling to use structured type instead of JSON string

### DIFF
--- a/src/nodes/generateReport.ts
+++ b/src/nodes/generateReport.ts
@@ -86,7 +86,7 @@ export async function generateReportNode(
   console.log('isRevision', isRevision);
   const finalReport = await generateFinalReport(llm, prompt);
   console.log('finalReport', finalReport);
-  const finalReportJson = JSON.stringify(finalReport);
+  const finalReportJson = finalReport;
   return {
     finalReport: finalReportJson,
     reportRevisionsIncrement: revisionIncrement,

--- a/src/state.ts
+++ b/src/state.ts
@@ -3,6 +3,7 @@ import {
   CompleteExtractedCompanyInfo,
   ExtractedKeyPerson,
   FallbackSearchResult,
+  GeneratedReport,
   UserAction,
 } from "./types.js";
 
@@ -27,7 +28,7 @@ export const CompanyResearchAnnotation = Annotation.Root({
   finalKeyPersons: Annotation<ExtractedKeyPerson[]>(),
 
   // The final JSON-based summary about the company
-  finalReport: Annotation<string>(),
+  finalReport: Annotation<GeneratedReport>(),
 
   // We'll store the user's action from the human review step
   userAction: Annotation<UserAction | null>(),
@@ -44,8 +45,8 @@ export const CompanyResearchAnnotation = Annotation.Root({
   }),
 
   // Array of generated report revisions
-  reportRevisions: Annotation<string[]>({
-    reducer: (state, update) => state.concat(update),
+  reportRevisions: Annotation<GeneratedReport[]>({
+    reducer: (state, update) => (state).concat(update),
     default: () => [],
   }),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import {
   extractedCompanyInfoSchema,
   fallbackSearchResultSchema,
+  generatedReportSchema,
 } from "./schema.js";
 
 import { extractedKeyPersonSchema } from "./schema.js";
@@ -25,10 +26,12 @@ type CompleteExtractedCompanyInfo = z.infer<
   typeof completeExtractedCompanyInfoSchema
 >;
 type FallbackSearchResult = z.infer<typeof fallbackSearchResultSchema>;
+type GeneratedReport = z.infer<typeof generatedReportSchema>;
 
 export {
   ExtractedCompanyInfo,
   ExtractedKeyPerson,
   CompleteExtractedCompanyInfo,
   FallbackSearchResult,
+  GeneratedReport
 };


### PR DESCRIPTION
1. Updated the generateReport function in `generateReport.ts`:
    - Removed unnecessary JSON.stringify conversion for the final report.
    - Directly returned the structured `finalReport` object for better visualization in Langgraph Studio.
    
2. Modified the `state.ts` file:
    - Changed the `finalReport` annotation to use the `GeneratedReport` type instead of a plain string.
    - Updated the `reportRevisions` annotation to store an array of `GeneratedReport` objects instead of strings.

3. Updated `types.ts`:
    - Introduced a new `GeneratedReport` type inferred from the `generatedReportSchema`.